### PR TITLE
Move ResourceBundle field to AbstractCommand.

### DIFF
--- a/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/AbstractCommand.java
+++ b/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/AbstractCommand.java
@@ -18,6 +18,7 @@ package zav.discord.blanc.command;
 
 import static zav.discord.blanc.databind.Rank.USER;
 
+import java.util.ResourceBundle;
 import java.util.concurrent.ExecutionException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.jetbrains.annotations.Contract;
@@ -32,6 +33,7 @@ import zav.discord.blanc.databind.Rank;
 public abstract class AbstractCommand implements Command {
   private final Rank requiredRank;
   private final CommandManager manager;
+  private final ResourceBundle i18n;
   
   /**
    * Creates a new instance of this class.
@@ -42,6 +44,7 @@ public abstract class AbstractCommand implements Command {
   protected AbstractCommand(Rank requiredRank, CommandManager manager) {
     this.requiredRank = requiredRank;
     this.manager = manager;
+    this.i18n = ResourceBundle.getBundle("i18n");
   }
   
   /**
@@ -58,5 +61,19 @@ public abstract class AbstractCommand implements Command {
   public void validate() throws ExecutionException {
     // Does the user have the required rank?
     manager.validate(requiredRank);
+  }
+  
+  /**
+   * Returns the internationalized message with the given key.
+   * The messages are stored in a file with name {@code i18n_XX.properties} in the local class path,
+   * with {@code XX} being the country code (e.g en, ru, ...).
+   *
+   * @param key The id of the i18n message.
+   * @param args Additional arguments which may be injected into the message.
+   * @return An internationalized string.
+   * @see String#format(String, Object...)
+   */
+  protected String getMessage(String key, Object... args) {
+    return String.format(i18n.getString(key), args);
   }
 }

--- a/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/CommandManager.java
+++ b/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/CommandManager.java
@@ -16,9 +16,7 @@
 
 package zav.discord.blanc.command;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
-import java.util.ResourceBundle;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import zav.discord.blanc.api.Client;
@@ -41,7 +39,6 @@ public class CommandManager {
    */
   protected final SlashCommandEvent event;
   private final RankValidator validator;
-  private final ResourceBundle resourceBundle;
   
   /**
    * Creates a new manager instance. A new instance is created for each command.
@@ -53,7 +50,6 @@ public class CommandManager {
     this.client = client;
     this.event = event;
     this.validator = new RankValidator(client.getEntityManagerFactory(), event.getUser());
-    this.resourceBundle = ResourceBundle.getBundle("i18n");
   }
   
   /**
@@ -64,16 +60,6 @@ public class CommandManager {
    */
   public void validate(Rank rank) throws InsufficientRankException {
     validator.validate(List.of(rank));
-  }
-  
-  /**
-   * Returns the resource bundle containing locale-specific strings.
-   *
-   * @return As described.
-   */
-  @SuppressFBWarnings(value = "EI_EXPOSE_REP")
-  public ResourceBundle getResourceBundle() {
-    return resourceBundle;
   }
   
   /**

--- a/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/AbstractGuildCommandTest.java
+++ b/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/AbstractGuildCommandTest.java
@@ -16,6 +16,7 @@
 
 package zav.discord.blanc.command;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -82,6 +83,14 @@ public class AbstractGuildCommandTest {
     // Not enough ranks & ranks are validated before permissions
     doThrow(InsufficientRankException.class).when(manager).validate(any(Rank.class));
     assertThrows(InsufficientRankException.class, () -> command.validate());
+  }
+  
+  /**
+   * Use Case: Language specific messages should be read from the local properties file.
+   */
+  @Test
+  public void testGetMessage() {
+    assertEquals(command.getMessage("foo"), "bar");
   }
   
   private static final class GuildCommand extends AbstractGuildCommand {

--- a/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/CommandManagerTest.java
+++ b/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/CommandManagerTest.java
@@ -1,7 +1,6 @@
 package zav.discord.blanc.command;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mockConstruction;
 
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
@@ -39,11 +38,6 @@ public class CommandManagerTest {
   public void testValidate() throws InsufficientRankException {
     // RankValidator has been mocked, hence the call should proceed without any error
     manager.validate(Rank.ROOT);
-  }
-  
-  @Test
-  public void testGetResourceBundle() {
-    assertNotNull(manager.getResourceBundle());
   }
   
   @Test

--- a/zav.discord.blanc.command/src/test/resources/i18n_en.properties
+++ b/zav.discord.blanc.command/src/test/resources/i18n_en.properties
@@ -14,3 +14,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+foo=bar

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/core/SupportCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/core/SupportCommand.java
@@ -16,7 +16,6 @@
 
 package zav.discord.blanc.runtime.command.core;
 
-import java.util.ResourceBundle;
 import javax.inject.Inject;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import zav.discord.blanc.command.AbstractCommand;
@@ -28,7 +27,6 @@ import zav.discord.blanc.databind.Credentials;
  */
 public class SupportCommand extends AbstractCommand {
   
-  private final ResourceBundle i18n;
   private final SlashCommandEvent event;
   private final String link;
   
@@ -44,11 +42,10 @@ public class SupportCommand extends AbstractCommand {
     super(manager);
     this.event = event;
     this.link = credentials.getInviteSupportServer();
-    this.i18n = manager.getResourceBundle();
   }
   
   @Override
   public void run() {
-    event.replyFormat(i18n.getString("server_invitation"), link).complete();
+    event.reply(getMessage("server_invitation", link)).complete();
   }
 }

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/BlacklistCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/BlacklistCommand.java
@@ -22,7 +22,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import java.util.Objects;
-import java.util.ResourceBundle;
 import javax.inject.Inject;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
@@ -40,7 +39,6 @@ import zav.discord.blanc.databind.GuildEntity;
 public class BlacklistCommand extends AbstractGuildCommand {
   private final EntityManagerFactory factory;
   private final SlashCommandEvent event;
-  private final ResourceBundle i18n;
   private final PatternCache cache;
   private final Client client;
   private final Guild guild;
@@ -58,7 +56,6 @@ public class BlacklistCommand extends AbstractGuildCommand {
     this.event = event;
     this.guild = event.getGuild();
     this.regex = Objects.requireNonNull(event.getOption("regex")).getAsString();
-    this.i18n = manager.getResourceBundle();
     this.client = manager.getClient();
     this.cache = client.getPatternCache();
     this.factory = client.getEntityManagerFactory();
@@ -73,10 +70,10 @@ public class BlacklistCommand extends AbstractGuildCommand {
       
       if (entity.getBlacklist().contains(regex)) {
         entity.getBlacklist().remove(regex);
-        response = i18n.getString("remove_blacklist");
+        response = getMessage("remove_blacklist", MarkdownSanitizer.escape(regex));
       } else {
         entity.getBlacklist().add(regex);
-        response = i18n.getString("add_blacklist");
+        response = getMessage("add_blacklist", MarkdownSanitizer.escape(regex));
       }
       
       entityManager.getTransaction().begin();
@@ -84,7 +81,7 @@ public class BlacklistCommand extends AbstractGuildCommand {
       entityManager.getTransaction().commit();
       
       cache.invalidate(guild);
-      event.replyFormat(response, MarkdownSanitizer.escape(regex)).complete();
+      event.reply(response).complete();
     }
   }
 }

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/RedditCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/RedditCommand.java
@@ -22,7 +22,6 @@ import jakarta.persistence.EntityManagerFactory;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.ResourceBundle;
 import javax.inject.Inject;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
@@ -46,7 +45,6 @@ import zav.discord.blanc.reddit.SubredditObservable;
  */
 public class RedditCommand extends AbstractGuildCommand {
   private static final String WEBHOOK = "Reddit";
-  private final ResourceBundle i18n;
   private final Client client;
   private final EntityManagerFactory factory;
   private final SubredditObservable reddit;
@@ -70,7 +68,6 @@ public class RedditCommand extends AbstractGuildCommand {
     this.client = manager.getClient();
     this.reddit = client.getSubredditObservable();
     this.factory = client.getEntityManagerFactory();
-    this.i18n = manager.getResourceBundle();
 
     this.subreddit = Objects.requireNonNull(event.getOption("subreddit"))
         .getAsString()
@@ -110,7 +107,7 @@ public class RedditCommand extends AbstractGuildCommand {
           webhook.delete().complete();
         }
     
-        response = i18n.getString("remove_subreddit");
+        response = getMessage("remove_subreddit", subreddit, target.getAsMention());
       } else {
         // Add subreddit to the database
         webhookEntity.getSubreddits().add(subreddit);
@@ -119,7 +116,7 @@ public class RedditCommand extends AbstractGuildCommand {
         reddit.addListener(subreddit, webhook);
 
         // Webhook has already been created, so we don't need to do it here
-        response = i18n.getString("add_subreddit");
+        response = getMessage("add_subreddit", subreddit, target.getAsMention());
       }
       
       // Update bi-directional associations
@@ -134,7 +131,7 @@ public class RedditCommand extends AbstractGuildCommand {
       entityManager.merge(webhookEntity);
       entityManager.getTransaction().commit();
       
-      event.replyFormat(response, subreddit, target.getAsMention()).complete();
+      event.reply(response).complete();
     }
   }
 }

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/RedditLegacyCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/RedditLegacyCommand.java
@@ -21,7 +21,6 @@ import jakarta.persistence.EntityManagerFactory;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.ResourceBundle;
 import javax.inject.Inject;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
@@ -47,7 +46,6 @@ public class RedditLegacyCommand extends AbstractGuildCommand {
   private final EntityManagerFactory factory;
   private final SubredditObservable reddit;
   private final SlashCommandEvent event;
-  private final ResourceBundle i18n;
   private final TextChannel target;
   private final String subreddit;
   private final Client client;
@@ -62,7 +60,6 @@ public class RedditLegacyCommand extends AbstractGuildCommand {
   @Inject
   public RedditLegacyCommand(SlashCommandEvent event, GuildCommandManager manager) {
     super(manager, Permission.MANAGE_CHANNEL);
-    this.i18n = manager.getResourceBundle();
     this.client = manager.getClient();
     this.factory = client.getEntityManagerFactory();
     this.reddit = client.getSubredditObservable();
@@ -99,12 +96,12 @@ public class RedditLegacyCommand extends AbstractGuildCommand {
         entityManager.merge(channelEntity);
         entityManager.getTransaction().commit();
     
-        response = i18n.getString("remove_subreddit");
+        response = getMessage("remove_subreddit", subreddit, target.getAsMention());
       } else {
-        response = i18n.getString("add_subreddit_deprecated");
+        response = getMessage("add_subreddit_deprecated", subreddit, target.getAsMention());
       }
       
-      event.replyFormat(response, subreddit, target.getAsMention()).complete();
+      event.reply(response).complete();
     }
   }
 }

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/core/SupportCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/core/SupportCommandTest.java
@@ -17,10 +17,8 @@
 package zav.discord.blanc.runtime.command.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import java.util.ResourceBundle;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,7 +37,6 @@ import zav.discord.blanc.databind.Credentials;
 @ExtendWith(MockitoExtension.class)
 public class SupportCommandTest {
   static final String supportServer = "https://discord.gg/xxxxxxxxxx";
-  static final ResourceBundle bundle = ResourceBundle.getBundle("i18n");
   
   @Captor ArgumentCaptor<String> response;  
   @Mock Credentials credentials;
@@ -53,17 +50,16 @@ public class SupportCommandTest {
    */
   @BeforeEach
   public void setUp() {
-    when(manager.getResourceBundle()).thenReturn(bundle);
     when(credentials.getInviteSupportServer()).thenReturn(supportServer);
     command = new SupportCommand(event, manager, credentials);
   }
   
   @Test
   public void testSendSupportLink() {
-    when(event.replyFormat(anyString(), response.capture())).thenReturn(reply);
+    when(event.reply(response.capture())).thenReturn(reply);
     
     command.run();
     
-    assertThat(response.getValue()).isEqualTo(supportServer);
+    assertThat(response.getValue()).endsWith(supportServer);
   }
 }

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/BlacklistCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/BlacklistCommandTest.java
@@ -65,7 +65,7 @@ public class BlacklistCommandTest extends AbstractDatabaseTest<GuildEntity> {
     when(event.getMember()).thenReturn(member);
     when(event.getGuild()).thenReturn(guild);
     when(event.getOption(anyString())).thenReturn(regex);
-    when(event.replyFormat(anyString(), anyString())).thenReturn(action);
+    when(event.reply(anyString())).thenReturn(action);
     when(regex.getAsString()).thenReturn("foo");
     when(client.getPatternCache()).thenReturn(cache);
     when(entityManager.find(eq(GuildEntity.class), any())).thenReturn(entity);

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/RedditCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/RedditCommandTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -86,7 +85,7 @@ public class RedditCommandTest extends AbstractDatabaseTest<WebhookEntity> {
     when(event.getMember()).thenReturn(member);
     when(event.getTextChannel()).thenReturn(channel);
     when(event.getOption(anyString())).thenReturn(subreddit);
-    when(event.replyFormat(anyString(), anyString(), nullable(String.class))).thenReturn(reply);
+    when(event.reply(anyString())).thenReturn(reply);
     when(subreddit.getAsString()).thenReturn("RedditDev");
     
     when(channel.retrieveWebhooks()).thenReturn(retrieveWebhooks);

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/RedditLegacyCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/RedditLegacyCommandTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -80,7 +79,7 @@ public class RedditLegacyCommandTest extends AbstractDatabaseTest<TextChannelEnt
     when(event.getMember()).thenReturn(member);
     when(event.getTextChannel()).thenReturn(channel);
     when(event.getOption(anyString())).thenReturn(subreddit);
-    when(event.replyFormat(anyString(), anyString(), nullable(String.class))).thenReturn(reply);
+    when(event.reply(anyString())).thenReturn(reply);
     when(subreddit.getAsString()).thenReturn("RedditDev");
     
     when(entityManager.find(eq(TextChannelEntity.class), any())).thenReturn(entity);


### PR DESCRIPTION
The resource bundle containing translated messages should not be called directly. Instead, AbstractCommand#getMessage should be used.