### PR TITLE
Move from Hibernate to EclipseLink.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 
 **/src/main/resources/*.json
 **/Entity.db
+**/createDDL.jdbc
 **/META-INF/MANIFEST.MF

--- a/pom.xml
+++ b/pom.xml
@@ -159,14 +159,19 @@
             
             <!-- JPA -->
             <dependency>
-                <groupId>org.hibernate.orm</groupId>
-                <artifactId>hibernate-community-dialects</artifactId>
-                <version>6.1.4.Final</version>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>eclipselink</artifactId>
+                <version>4.0.0</version>
             </dependency>
             <dependency>
-                <groupId>org.hibernate.orm</groupId>
-                <artifactId>hibernate-core</artifactId>
-                <version>6.1.4.Final</version>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.extension</artifactId>
+                <version>4.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.jpa</artifactId>
+                <version>4.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.xerial</groupId>

--- a/zav.discord.blanc.api/pom.xml
+++ b/zav.discord.blanc.api/pom.xml
@@ -109,8 +109,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-community-dialects</artifactId>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.extension</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/listener/TextChannelListenerTest.java
+++ b/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/listener/TextChannelListenerTest.java
@@ -56,10 +56,6 @@ public class TextChannelListenerTest {
   @Mock GuildLeaveEvent leaveEvent;
   @Mock TextChannelDeleteEvent deleteEvent;
   
-  static {
-    System.setProperty("org.jboss.logging.provider", "slf4j");
-  }
-  
   /**
    * Initializes the text channel listener.<br>
    * The database used by the listener is initialized with the entities {@code Webhook.json},

--- a/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/util/AutoResponseCacheTest.java
+++ b/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/util/AutoResponseCacheTest.java
@@ -48,10 +48,6 @@ public class AutoResponseCacheTest {
   AutoResponseEntity autoResponse;
   @Mock Guild guild;
   
-  static {
-    System.setProperty("org.jboss.logging.provider", "slf4j");
-  }
-  
   /**
    * Initializes the pattern cache. The cache will load a single guild entity, containing an entry
    * to automatically response to the string {@code foo} with {@code bar}.

--- a/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/util/PatternCacheTest.java
+++ b/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/util/PatternCacheTest.java
@@ -48,10 +48,6 @@ public class PatternCacheTest {
   PatternCache cache;
   @Mock Guild guild;
   
-  static {
-    System.setProperty("org.jboss.logging.provider", "slf4j");
-  }
-  
   /**
    * Initializes the pattern cache. The cache will load a single guild entity, containing both the
    * words {@code banana} and {@code pizza} as blacklisted expressions.

--- a/zav.discord.blanc.api/src/test/resources/META-INF/persistence.xml
+++ b/zav.discord.blanc.api/src/test/resources/META-INF/persistence.xml
@@ -20,22 +20,24 @@
              version="2.0">
 
     <persistence-unit name="discord-entities">
-        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>zav.discord.blanc.databind.AutoResponseEntity</class>
         <class>zav.discord.blanc.databind.GuildEntity</class>
         <class>zav.discord.blanc.databind.TextChannelEntity</class>
         <class>zav.discord.blanc.databind.UserEntity</class>
         <class>zav.discord.blanc.databind.WebhookEntity</class>
         <properties>
-            <property name="hibernate.dialect" value="org.hibernate.community.dialect.SQLiteDialect" />
             <property name="jakarta.persistence.jdbc.driver" value="org.sqlite.JDBC" />
             <property name="jakarta.persistence.jdbc.url" value="jdbc:sqlite:file::memory:?cache=shared" />
             <property name="jakarta.persistence.jdbc.user" value="" />
             <property name="jakarta.persistence.jdbc.password" value="" />
-            <property name="hibernate.show_sql" value="false" />
-            <property name="hibernate.format_sql" value="false" />
-            <property name="hibernate.connection.charSet" value="UTF-8" />
-            <property name="hibernate.hbm2ddl.auto" value="create" />
+            <property name="eclipselink.ddl-generation" value="create-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="both"/>
+            <property name="eclipselink.allow-zero-id" value="true"/>
+            <property name="eclipselink.logging.level.connection" value="FINE"/>
+            <property name="eclipselink.logging.level.jpa" value="FINER"/>
+            <property name="eclipselink.logging.level.sql" value="FINEST"/>
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/zav.discord.blanc.command/pom.xml
+++ b/zav.discord.blanc.command/pom.xml
@@ -81,8 +81,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-community-dialects</artifactId>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.extension</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/internal/PermissionValidatorTest.java
+++ b/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/internal/PermissionValidatorTest.java
@@ -55,10 +55,6 @@ public class PermissionValidatorTest {
   PermissionValidator validator;
   Set<Permission> permissions;
   
-  static {
-    System.setProperty("org.jboss.logging.provider", "slf4j");
-  }
-  
   /**
    * Initializes the permission validator. By default, every user has administrative permissions.
    */

--- a/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/internal/RankValidatorTest.java
+++ b/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/internal/RankValidatorTest.java
@@ -49,10 +49,6 @@ public class RankValidatorTest {
   RankValidator validator;
   Set<Rank> ranks;
   
-  static {
-    System.setProperty("org.jboss.logging.provider", "slf4j");
-  }
-  
   /**
    * Initializes the permission validator. By default, every user is root.
    */

--- a/zav.discord.blanc.command/src/test/resources/META-INF/persistence.xml
+++ b/zav.discord.blanc.command/src/test/resources/META-INF/persistence.xml
@@ -20,22 +20,24 @@
              version="2.0">
 
     <persistence-unit name="discord-entities">
-        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>zav.discord.blanc.databind.AutoResponseEntity</class>
         <class>zav.discord.blanc.databind.GuildEntity</class>
         <class>zav.discord.blanc.databind.TextChannelEntity</class>
         <class>zav.discord.blanc.databind.UserEntity</class>
         <class>zav.discord.blanc.databind.WebhookEntity</class>
         <properties>
-            <property name="hibernate.dialect" value="org.hibernate.community.dialect.SQLiteDialect" />
             <property name="jakarta.persistence.jdbc.driver" value="org.sqlite.JDBC" />
             <property name="jakarta.persistence.jdbc.url" value="jdbc:sqlite:file::memory:?cache=shared" />
             <property name="jakarta.persistence.jdbc.user" value="" />
             <property name="jakarta.persistence.jdbc.password" value="" />
-            <property name="hibernate.show_sql" value="false" />
-            <property name="hibernate.format_sql" value="false" />
-            <property name="hibernate.connection.charSet" value="UTF-8" />
-            <property name="hibernate.hbm2ddl.auto" value="create" />
+            <property name="eclipselink.ddl-generation" value="create-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="both"/>
+            <property name="eclipselink.allow-zero-id" value="true"/>
+            <property name="eclipselink.logging.level.connection" value="FINE"/>
+            <property name="eclipselink.logging.level.jpa" value="FINER"/>
+            <property name="eclipselink.logging.level.sql" value="FINEST"/>
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/zav.discord.blanc.databind/pom.xml
+++ b/zav.discord.blanc.databind/pom.xml
@@ -70,8 +70,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-community-dialects</artifactId>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.extension</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/zav.discord.blanc.databind/src/test/java/zav/discord/blanc/databind/GuildEntityTest.java
+++ b/zav.discord.blanc.databind/src/test/java/zav/discord/blanc/databind/GuildEntityTest.java
@@ -21,16 +21,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class GuildEntityTest {
   // Arbitrary but fixed. Because of GenerationType.IDENTITY, the first element gets the id 1
-  private static final long AUTORESPONSE_ID = 1L;
+  private static final long AUTORESPONSE_ID = 0L;
   
   EntityManagerFactory factory;
   @Mock Guild guild;
   @Mock TextChannel channel;
   @Mock Webhook webhook;
-  
-  static {
-    System.setProperty("org.jboss.logging.provider", "slf4j");
-  }
   
   @BeforeEach
   public void setUp() {

--- a/zav.discord.blanc.databind/src/test/java/zav/discord/blanc/databind/RankTest.java
+++ b/zav.discord.blanc.databind/src/test/java/zav/discord/blanc/databind/RankTest.java
@@ -48,10 +48,6 @@ public class RankTest {
   @Mock EntityManager mockManager;
   @Mock User user;
   
-  static {
-    System.setProperty("org.jboss.logging.provider", "slf4j");
-  }
-  
   @BeforeEach
   public void setUp() {
     factory = Persistence.createEntityManagerFactory("discord-entities");

--- a/zav.discord.blanc.databind/src/test/java/zav/discord/blanc/databind/TextChannelEntityTest.java
+++ b/zav.discord.blanc.databind/src/test/java/zav/discord/blanc/databind/TextChannelEntityTest.java
@@ -24,10 +24,6 @@ public class TextChannelEntityTest {
   @Mock TextChannel channel;
   @Mock Webhook webhook;
   
-  static {
-    System.setProperty("org.jboss.logging.provider", "slf4j");
-  }
-  
   @BeforeEach
   public void setUp() {
     factory = Persistence.createEntityManagerFactory("discord-entities");

--- a/zav.discord.blanc.databind/src/test/java/zav/discord/blanc/databind/WebhookEntityTest.java
+++ b/zav.discord.blanc.databind/src/test/java/zav/discord/blanc/databind/WebhookEntityTest.java
@@ -24,10 +24,6 @@ public class WebhookEntityTest {
   @Mock TextChannel channel;
   @Mock Webhook webhook;
   
-  static {
-    System.setProperty("org.jboss.logging.provider", "slf4j");
-  }
-  
   @BeforeEach
   public void setUp() {
     factory = Persistence.createEntityManagerFactory("discord-entities");

--- a/zav.discord.blanc.databind/src/test/resources/META-INF/persistence.xml
+++ b/zav.discord.blanc.databind/src/test/resources/META-INF/persistence.xml
@@ -20,22 +20,24 @@
              version="2.0">
 
     <persistence-unit name="discord-entities">
-        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>zav.discord.blanc.databind.AutoResponseEntity</class>
         <class>zav.discord.blanc.databind.GuildEntity</class>
         <class>zav.discord.blanc.databind.TextChannelEntity</class>
         <class>zav.discord.blanc.databind.UserEntity</class>
         <class>zav.discord.blanc.databind.WebhookEntity</class>
         <properties>
-            <property name="hibernate.dialect" value="org.hibernate.community.dialect.SQLiteDialect" />
             <property name="jakarta.persistence.jdbc.driver" value="org.sqlite.JDBC" />
             <property name="jakarta.persistence.jdbc.url" value="jdbc:sqlite:file::memory:?cache=shared" />
             <property name="jakarta.persistence.jdbc.user" value="" />
             <property name="jakarta.persistence.jdbc.password" value="" />
-            <property name="hibernate.show_sql" value="false" />
-            <property name="hibernate.format_sql" value="false" />
-            <property name="hibernate.connection.charSet" value="UTF-8" />
-            <property name="hibernate.hbm2ddl.auto" value="create" />
+            <property name="eclipselink.ddl-generation" value="create-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="both"/>
+            <property name="eclipselink.allow-zero-id" value="true"/>
+            <property name="eclipselink.logging.level.connection" value="FINE"/>
+            <property name="eclipselink.logging.level.jpa" value="FINER"/>
+            <property name="eclipselink.logging.level.sql" value="FINEST"/>
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/zav.discord.blanc.reddit/pom.xml
+++ b/zav.discord.blanc.reddit/pom.xml
@@ -104,8 +104,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-community-dialects</artifactId>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.extension</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/zav.discord.blanc.reddit/src/test/java/zav/discord/blanc/reddit/TextChannelInitializerTest.java
+++ b/zav.discord.blanc.reddit/src/test/java/zav/discord/blanc/reddit/TextChannelInitializerTest.java
@@ -49,10 +49,6 @@ public class TextChannelInitializerTest {
   TextChannelEntity entity;
   TextChannelInitializer initializer;
   
-  static {
-    System.setProperty("org.jboss.logging.provider", "slf4j");
-  }
-  
   /**
    * Creates a new instance of the text channel initializer and loads the database with a single
    * entity. The entity is registered to the subreddit {@code RedditDev}.

--- a/zav.discord.blanc.reddit/src/test/java/zav/discord/blanc/reddit/WebhookInitializerTest.java
+++ b/zav.discord.blanc.reddit/src/test/java/zav/discord/blanc/reddit/WebhookInitializerTest.java
@@ -56,10 +56,6 @@ public class WebhookInitializerTest {
   EntityManager entityManager;
   WebhookEntity entity;
   
-  static {
-    System.setProperty("org.jboss.logging.provider", "slf4j");
-  }
-  
   /**
    * Creates a new instance of the webhook initializer and loads the database with a single entity.
    * The entity is registered to the subreddit {@code RedditDev}.

--- a/zav.discord.blanc.reddit/src/test/resources/META-INF/persistence.xml
+++ b/zav.discord.blanc.reddit/src/test/resources/META-INF/persistence.xml
@@ -20,22 +20,24 @@
              version="2.0">
 
     <persistence-unit name="discord-entities">
-        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>zav.discord.blanc.databind.AutoResponseEntity</class>
         <class>zav.discord.blanc.databind.GuildEntity</class>
         <class>zav.discord.blanc.databind.TextChannelEntity</class>
         <class>zav.discord.blanc.databind.UserEntity</class>
         <class>zav.discord.blanc.databind.WebhookEntity</class>
         <properties>
-            <property name="dialect" value="org.sqlite.hibernate.dialect.SQLiteDialect" />
             <property name="jakarta.persistence.jdbc.driver" value="org.sqlite.JDBC" />
             <property name="jakarta.persistence.jdbc.url" value="jdbc:sqlite:file::memory:?cache=shared" />
             <property name="jakarta.persistence.jdbc.user" value="" />
             <property name="jakarta.persistence.jdbc.password" value="" />
-            <property name="hibernate.show_sql" value="false" />
-            <property name="hibernate.format_sql" value="false" />
-            <property name="hibernate.connection.charSet" value="UTF-8" />
-            <property name="hibernate.hbm2ddl.auto" value="create" />
+            <property name="eclipselink.ddl-generation" value="create-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="both"/>
+            <property name="eclipselink.allow-zero-id" value="true"/>
+            <property name="eclipselink.logging.level.connection" value="FINE"/>
+            <property name="eclipselink.logging.level.jpa" value="FINER"/>
+            <property name="eclipselink.logging.level.sql" value="FINEST"/>
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/zav.discord.blanc.runtime/pom.xml
+++ b/zav.discord.blanc.runtime/pom.xml
@@ -87,10 +87,15 @@
             <scope>runtime</scope>
         </dependency>        
         <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-community-dialects</artifactId>
-            <scope>runtime</scope>
-        </dependency>        
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.extension</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/Main.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/Main.java
@@ -61,10 +61,6 @@ import zav.jrc.databind.io.UserAgentEntity;
  */
 public class Main {
   
-  static {
-    System.setProperty("org.jboss.logging.provider", "slf4j");
-  }
-  
   private static final String DISCORD_CREDENTIALS = "DiscordUser.json";
   private static final File REDDIT_CREDENTIALS = new File("RedditUser.json");
   private static final File USER_AGENT = new File("UserAgent.json");

--- a/zav.discord.blanc.runtime/src/main/resources/META-INF/persistence.xml
+++ b/zav.discord.blanc.runtime/src/main/resources/META-INF/persistence.xml
@@ -20,22 +20,24 @@
              version="2.0">
 
     <persistence-unit name="discord-entities">
-        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>zav.discord.blanc.databind.AutoResponseEntity</class>
         <class>zav.discord.blanc.databind.GuildEntity</class>
         <class>zav.discord.blanc.databind.TextChannelEntity</class>
         <class>zav.discord.blanc.databind.UserEntity</class>
         <class>zav.discord.blanc.databind.WebhookEntity</class>
         <properties>
-            <property name="dialect" value="org.sqlite.hibernate.dialect.SQLiteDialect" />
             <property name="jakarta.persistence.jdbc.driver" value="org.sqlite.JDBC" />
             <property name="jakarta.persistence.jdbc.url" value="jdbc:sqlite:file:Entities.db" />
             <property name="jakarta.persistence.jdbc.user" value="" />
             <property name="jakarta.persistence.jdbc.password" value="" />
-            <property name="hibernate.show_sql" value="false" />
-            <property name="hibernate.format_sql" value="false" />
-            <property name="hibernate.connection.charSet" value="UTF-8" />
-            <property name="hibernate.hbm2ddl.auto" value="update" />
+            <property name="eclipselink.ddl-generation" value="create-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="both"/>
+            <property name="eclipselink.allow-zero-id" value="true"/>
+            <property name="eclipselink.logging.level.connection" value="FINE"/>
+            <property name="eclipselink.logging.level.jpa" value="FINER"/>
+            <property name="eclipselink.logging.level.sql" value="FINEST"/>
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/zav.discord.blanc.runtime/src/test/resources/META-INF/persistence.xml
+++ b/zav.discord.blanc.runtime/src/test/resources/META-INF/persistence.xml
@@ -20,21 +20,24 @@
              version="2.0">
 
     <persistence-unit name="discord-entities">
-        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>zav.discord.blanc.databind.AutoResponseEntity</class>
         <class>zav.discord.blanc.databind.GuildEntity</class>
         <class>zav.discord.blanc.databind.TextChannelEntity</class>
         <class>zav.discord.blanc.databind.UserEntity</class>
         <class>zav.discord.blanc.databind.WebhookEntity</class>
         <properties>
-            <property name="dialect" value="org.sqlite.hibernate.dialect.SQLiteDialect" />
             <property name="jakarta.persistence.jdbc.driver" value="org.sqlite.JDBC" />
             <property name="jakarta.persistence.jdbc.url" value="jdbc:sqlite:file::memory:?cache=shared" />
             <property name="jakarta.persistence.jdbc.user" value="" />
             <property name="jakarta.persistence.jdbc.password" value="" />
-            <property name="hibernate.show_sql" value="false" />
-            <property name="hibernate.format_sql" value="false" />
-            <property name="hibernate.connection.charSet" value="UTF-8" />
-            <property name="hibernate.hbm2ddl.auto" value="create" />
+            <property name="eclipselink.ddl-generation" value="create-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="both"/>
+            <property name="eclipselink.allow-zero-id" value="true"/>
+            <property name="eclipselink.logging.level.connection" value="FINE"/>
+            <property name="eclipselink.logging.level.jpa" value="FINER"/>
+            <property name="eclipselink.logging.level.sql" value="FINEST"/>
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger"/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
Both frameworks support Jakarta Persistence 3+ so both can be used interchangeably. However, EclipseLink has a much cleaner dependency tree, which is why this project should use it instead.