### PR TITLE
Add a reply method to the base command.

### DIFF
--- a/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/AbstractCommand.java
+++ b/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/AbstractCommand.java
@@ -16,8 +16,12 @@
 
 package zav.discord.blanc.command;
 
+import java.text.MessageFormat;
 import java.util.ResourceBundle;
 import java.util.concurrent.ExecutionException;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.utils.MarkdownSanitizer;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.jetbrains.annotations.Contract;
 import zav.discord.blanc.api.Command;
@@ -29,15 +33,18 @@ import zav.discord.blanc.databind.Rank;
  */
 @NonNullByDefault
 public abstract class AbstractCommand implements Command {
+  private final SlashCommandEvent event;
   private final CommandManager manager;
   private final ResourceBundle i18n;
   
   /**
    * Creates a new instance of this class.
    *
+   * @param event The event triggering this command.
    * @param manager The command-specific manager.
    */
-  protected AbstractCommand(CommandManager manager) {
+  protected AbstractCommand(SlashCommandEvent event, CommandManager manager) {
+    this.event = event;
     this.manager = manager;
     this.i18n = ResourceBundle.getBundle("i18n");
   }
@@ -65,5 +72,21 @@ public abstract class AbstractCommand implements Command {
    */
   protected String getMessage(String key, Object... args) {
     return String.format(i18n.getString(key), args);
+  }
+
+  protected void reply(Object content, boolean ephemeral) {
+    event.reply(MarkdownSanitizer.escape(content.toString())).setEphemeral(ephemeral).complete();
+  }
+
+  protected void reply(Object content) {
+    reply(content, false);
+  }
+
+  protected void reply(String pattern, Object... args) {
+    reply(MessageFormat.format(pattern, args));
+  }
+
+  protected void reply(MessageEmbed messageEmbed) {
+    event.replyEmbeds(messageEmbed).complete();
   }
 }

--- a/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/AbstractGuildCommand.java
+++ b/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/AbstractGuildCommand.java
@@ -20,6 +20,7 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.jetbrains.annotations.Contract;
 
@@ -35,10 +36,11 @@ public abstract class AbstractGuildCommand extends AbstractCommand {
   /**
    * Creates a new instance of this class.
    *
+   * @param event The event triggering this command.
    * @param manager The command-specific manager.
    */
-  protected AbstractGuildCommand(GuildCommandManager manager) {
-    super(manager);
+  protected AbstractGuildCommand(SlashCommandEvent event, GuildCommandManager manager) {
+    super(event, manager);
     this.manager = manager;
   }
   

--- a/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/AbstractGuildCommandTest.java
+++ b/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/AbstractGuildCommandTest.java
@@ -22,7 +22,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -96,7 +98,7 @@ public class AbstractGuildCommandTest {
   private static final class GuildCommand extends AbstractGuildCommand {
     
     private GuildCommand(GuildCommandManager manager) {
-      super(manager);
+      super(mock(SlashCommandEvent.class), manager);
     }
   
     @Override

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/core/MathCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/core/MathCommand.java
@@ -26,7 +26,6 @@ import zav.discord.blanc.command.CommandManager;
  * This command can solve simple mathematical expressions.
  */
 public class MathCommand extends AbstractCommand {
-  private final SlashCommandEvent event;
   private final JexlParser jexl;
   private final String value;
   
@@ -37,14 +36,13 @@ public class MathCommand extends AbstractCommand {
    * @param manager The manager instance for this command.
    */
   public MathCommand(SlashCommandEvent event, CommandManager manager) {
-    super(manager);
+    super(event, manager);
     this.jexl = new JexlParser();
     this.value = Objects.requireNonNull(event.getOption("value")).getAsString();
-    this.event = event;
   }
   
   @Override
   public void run() {
-    event.reply(jexl.evaluate(value).toString()).complete();
+    reply(jexl.evaluate(value));
   }
 }

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/core/SupportCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/core/SupportCommand.java
@@ -25,7 +25,6 @@ import zav.discord.blanc.command.CommandManager;
  */
 public class SupportCommand extends AbstractCommand {
   
-  private final SlashCommandEvent event;
   private final String link;
   
   /**
@@ -35,13 +34,12 @@ public class SupportCommand extends AbstractCommand {
    * @param manager The manager instance for this command.
    */
   public SupportCommand(SlashCommandEvent event, CommandManager manager) {
-    super(manager);
-    this.event = event;
+    super(event, manager);
     this.link = manager.getClient().getCredentials().getInviteSupportServer();
   }
   
   @Override
   public void run() {
-    event.reply(getMessage("server_invitation", link)).complete();
+    reply(getMessage("server_invitation", link));
   }
 }

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/dev/FailsafeCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/dev/FailsafeCommand.java
@@ -46,8 +46,8 @@ public class FailsafeCommand extends AbstractCommand {
       "I will direct this personally.",
       "Direct intervention is necessary.",
       "Relinquish your form to us.",
-      "Your minions have failed, %s.",
-      "Your cannot stop us, %s.",
+      "Your minions have failed, {0}.",
+      "Your cannot stop us, {0}.",
       "Submit now!",
       "This is true power.",
       "Progress cannot be halted.",
@@ -65,7 +65,7 @@ public class FailsafeCommand extends AbstractCommand {
       "We are not finished.",
       "Releasing control of this form.",
       "Destroying this body gains you nothing.",
-      "This changes nothing, %s.",
+      "This changes nothing, {0}.",
       "You have only delayed the inevitable.",
       "You are no longer relevant.",
       "Your interference has ended.",
@@ -73,13 +73,12 @@ public class FailsafeCommand extends AbstractCommand {
       "We will find another way.",
       "This body does not matter.",
       "I am releasing this form.",
-      "Impressive, %s.",
+      "Impressive, {0}.",
       "%s, you could have been useful.",
-      "You will regret your resistance, %s."
+      "You will regret your resistance, {0}."
   };
 
   private final User author;
-  private final SlashCommandEvent event;
   private final Client client;
   private final EntityManagerFactory factory;
   
@@ -90,9 +89,8 @@ public class FailsafeCommand extends AbstractCommand {
    * @param manager The manager instance for this command.
    */
   public FailsafeCommand(SlashCommandEvent event, CommandManager manager) {
-    super(manager);
+    super(event, manager);
     this.author = event.getUser();
-    this.event = event;
     this.client = manager.getClient();
     this.factory = client.getEntityManagerFactory();
   }
@@ -129,7 +127,7 @@ public class FailsafeCommand extends AbstractCommand {
       entityManager.merge(entity);
       entityManager.getTransaction().commit();
       
-      event.replyFormat(response, author.getAsMention()).complete();
+      reply(response, author.getAsMention());
     }
   }
 }

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/dev/KillCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/dev/KillCommand.java
@@ -31,7 +31,6 @@ import zav.discord.blanc.databind.Rank;
 public class KillCommand extends AbstractCommand {
 
   private final Client client;
-  private final SlashCommandEvent event;
   private final ScheduledExecutorService eventQueue;
   
   /**
@@ -41,8 +40,7 @@ public class KillCommand extends AbstractCommand {
    * @param manager The manager instance for this command.
    */
   public KillCommand(SlashCommandEvent event, CommandManager manager) {
-    super(manager);
-    this.event = event;
+    super(event, manager);
     this.client = manager.getClient();
     this.eventQueue = client.getEventQueue();
   }
@@ -55,7 +53,7 @@ public class KillCommand extends AbstractCommand {
   @Override
   @SuppressFBWarnings(value = "DM_EXIT")
   public void run() {
-    event.reply("Goodbye~").setEphemeral(true).complete();
+    reply("Goodbye~", true);
 
     eventQueue.shutdown();
     

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/dev/SayCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/dev/SayCommand.java
@@ -27,7 +27,6 @@ import zav.discord.blanc.databind.Rank;
  */
 public class SayCommand extends AbstractCommand {
   
-  private final SlashCommandEvent event;
   private final String content;
   
   /**
@@ -37,8 +36,7 @@ public class SayCommand extends AbstractCommand {
    * @param manager The manager instance for this command.
    */
   public SayCommand(SlashCommandEvent event, CommandManager manager) {
-    super(manager);
-    this.event = event;
+    super(event, manager);
     this.content = Objects.requireNonNull(event.getOption("content")).getAsString();
   }
   
@@ -49,6 +47,6 @@ public class SayCommand extends AbstractCommand {
 
   @Override
   public void run() {
-    event.reply(content).complete();
+    reply(content);
   }
 }

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/dev/StatusCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/dev/StatusCommand.java
@@ -47,7 +47,6 @@ public class StatusCommand extends AbstractCommand {
   private final EmbedBuilder messageEmbed = new EmbedBuilder();
   private final SystemInfo systemInfo = new SystemInfo();
   private final HardwareAbstractionLayer hardware = systemInfo.getHardware();
-  private final SlashCommandEvent event;
   
   private OperatingSystem os;
   private OSProcess process;
@@ -72,8 +71,7 @@ public class StatusCommand extends AbstractCommand {
    * @param manager The command-specific manager.
    */
   public StatusCommand(SlashCommandEvent event, CommandManager manager) {
-    super(manager);
-    this.event = event;
+    super(event, manager);
     
     os = systemInfo.getOperatingSystem();
     process = os.getProcess(os.getProcessId());
@@ -125,7 +123,7 @@ public class StatusCommand extends AbstractCommand {
     // Global Uptime
     messageEmbed.addField("Global Memory", getGlobalMemory(), false);
     
-    event.replyEmbeds(messageEmbed.build()).complete();
+    reply(messageEmbed.build());
   }
   
   private String getFrequencies() {

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/AbstractDatabaseCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/AbstractDatabaseCommand.java
@@ -5,7 +5,6 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
-import net.dv8tion.jda.api.utils.MarkdownSanitizer;
 import zav.discord.blanc.api.Client;
 import zav.discord.blanc.command.AbstractGuildCommand;
 import zav.discord.blanc.command.GuildCommandManager;
@@ -18,7 +17,7 @@ public abstract class AbstractDatabaseCommand extends AbstractGuildCommand {
   private final EntityManagerFactory factory;
   
   protected AbstractDatabaseCommand(SlashCommandEvent event, GuildCommandManager manager) {
-    super(manager);
+    super(event, manager);
     this.event = event;
     this.guild = event.getGuild();
     this.client = manager.getClient();
@@ -47,7 +46,7 @@ public abstract class AbstractDatabaseCommand extends AbstractGuildCommand {
       entityManager.merge(entity);
       entityManager.getTransaction().commit();
       
-      event.reply(MarkdownSanitizer.escape(response)).complete();
+      reply(response);
     }
   }
 

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/AbstractRedditInfoCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/AbstractRedditInfoCommand.java
@@ -35,7 +35,7 @@ public abstract class AbstractRedditInfoCommand extends AbstractGuildCommand imp
    * @param manager The manager instance for this command.
    */
   public AbstractRedditInfoCommand(SlashCommandEvent event, GuildCommandManager manager) {
-    super(manager);
+    super(event, manager);
     this.guild = event.getGuild();
     this.channel = event.getTextChannel();
     this.manager = manager;

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/BlacklistInfoCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/BlacklistInfoCommand.java
@@ -50,7 +50,7 @@ public class BlacklistInfoCommand extends AbstractGuildCommand implements RichRe
    * @param manager The manager instance for this command.
    */
   public BlacklistInfoCommand(SlashCommandEvent event, GuildCommandManager manager) {
-    super(manager);
+    super(event, manager);
     this.guild = event.getGuild();
     this.manager = manager;
     this.client = manager.getClient();

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/LegacyRedditRemoveCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/LegacyRedditRemoveCommand.java
@@ -57,7 +57,7 @@ public class LegacyRedditRemoveCommand extends AbstractGuildCommand {
    * @param manager The manager instance for this command.
    */
   public LegacyRedditRemoveCommand(SlashCommandEvent event, GuildCommandManager manager) {
-    super(manager);
+    super(event, manager);
     this.event = event;
     this.guild = event.getGuild();
     this.client = manager.getClient();
@@ -84,7 +84,7 @@ public class LegacyRedditRemoveCommand extends AbstractGuildCommand {
       entityManager.merge(guildEntity);
       entityManager.getTransaction().commit();
       
-      event.reply(response).complete();
+      reply(response);
     }
   }
 

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/ResponseInfoCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/ResponseInfoCommand.java
@@ -34,7 +34,7 @@ public class ResponseInfoCommand extends AbstractGuildCommand implements RichRes
    * @param manager The manager instance for this command.
    */
   public ResponseInfoCommand(SlashCommandEvent event, GuildCommandManager manager) {
-    super(manager);
+    super(event, manager);
     this.guild = event.getGuild();
     this.manager = manager;
     this.client = manager.getClient();


### PR DESCRIPTION
This way we don't have to use event.reply(...).complete() over and over again. Furthermore, we can easily ensure that Markdown is escaped.