### PR TITLE
Introduce an application context to hold all objects.

### DIFF
--- a/zav.discord.blanc.api/pom.xml
+++ b/zav.discord.blanc.api/pom.xml
@@ -34,17 +34,8 @@
             <artifactId>blanc-databind</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>zav.discord.blanc</groupId>
-            <artifactId>blanc-reddit</artifactId>
-            <version>${project.version}</version>
-        </dependency>
         
         <!-- Compile Dependencies -->
-        <dependency>
-            <groupId>zav.jrc</groupId>
-            <artifactId>jrc-client</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>

--- a/zav.discord.blanc.api/src/main/java/zav/discord/blanc/api/util/ApplicationContext.java
+++ b/zav.discord.blanc.api/src/main/java/zav/discord/blanc/api/util/ApplicationContext.java
@@ -1,0 +1,6 @@
+package zav.discord.blanc.api.util;
+
+public interface ApplicationContext {
+  <T> T get(Class<T> clazz);
+  <T> void bind(Class<T> clazz, T object);
+}

--- a/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/ClientTest.java
+++ b/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/ClientTest.java
@@ -18,11 +18,13 @@ package zav.discord.blanc.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import net.dv8tion.jda.api.JDA;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +33,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import zav.discord.blanc.api.util.ShardSupplier;
 import zav.discord.blanc.databind.Credentials;
-import zav.jrc.client.UserlessClient;
 
 /**
  * Test class for the shards over which the client is split.
@@ -40,7 +41,6 @@ import zav.jrc.client.UserlessClient;
 public class ClientTest {
   @Mock ShardSupplier supplier;
   @Mock Credentials credentials;
-  @Mock UserlessClient jrc;
   List<JDA> shards;
   Client client;
   
@@ -56,8 +56,9 @@ public class ClientTest {
       return null;
     }).when(supplier).forEachRemaining(any());
     
-    client = new Client(credentials, jrc);
+    client = new Client();
     client.postConstruct(supplier);
+    client.bind(Object.class, new Object());
   }
   
   /**
@@ -82,32 +83,12 @@ public class ClientTest {
   }
   
   @Test
-  public void testGetCredentials() {
-    assertEquals(client.getCredentials(), credentials);
+  public void testGet() {
+    assertNotNull(client.get(Object.class));
   }
   
   @Test
-  public void testGetEventQueue() {
-    assertNotNull(client.getEventQueue());
-  }
-  
-  @Test
-  public void testGetPatternCache() {
-    assertNotNull(client.getPatternCache());
-  }
-  
-  @Test
-  public void testGetSiteCache() {
-    assertNotNull(client.getSiteCache());
-  }
-  
-  @Test
-  public void testGetAutoResonseCache() {
-    assertNotNull(client.getAutoResponseCache());
-  }
-  
-  @Test
-  public void testGetSubredditObservable() {
-    assertNotNull(client.getSubredditObservable());
+  public void testGetUnknown() {
+    assertThrows(NoSuchElementException.class, () -> client.get(String.class));
   }
 }

--- a/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/GuildCommandManager.java
+++ b/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/GuildCommandManager.java
@@ -82,7 +82,7 @@ public class GuildCommandManager extends CommandManager {
     if (pages.isEmpty()) {
       event.reply("No entries.").complete();
     } else {
-      SiteCache cache = client.getSiteCache();
+      SiteCache cache = client.get(SiteCache.class);
       
       // Build site
       Site site = Site.create(pages, event.getUser());

--- a/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/GuildCommandManagerTest.java
+++ b/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/GuildCommandManagerTest.java
@@ -84,7 +84,7 @@ public class GuildCommandManagerTest {
     when(action.complete()).thenReturn(hook);
     when(hook.retrieveOriginal()).thenReturn(response);
     when(response.complete()).thenReturn(message);
-    when(client.getSiteCache()).thenReturn(cache);
+    when(client.get(SiteCache.class)).thenReturn(cache);
     
     manager.submit(List.of(page));
     

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/core/SupportCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/core/SupportCommand.java
@@ -19,6 +19,7 @@ package zav.discord.blanc.runtime.command.core;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import zav.discord.blanc.command.AbstractCommand;
 import zav.discord.blanc.command.CommandManager;
+import zav.discord.blanc.databind.Credentials;
 
 /**
  * This command prints an invitation link to the support server.
@@ -37,7 +38,7 @@ public class SupportCommand extends AbstractCommand {
   public SupportCommand(SlashCommandEvent event, CommandManager manager) {
     super(manager);
     this.event = event;
-    this.link = manager.getClient().getCredentials().getInviteSupportServer();
+    this.link = manager.getClient().get(Credentials.class).getInviteSupportServer();
   }
   
   @Override

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/dev/KillCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/dev/KillCommand.java
@@ -44,7 +44,7 @@ public class KillCommand extends AbstractCommand {
     super(manager);
     this.event = event;
     this.client = manager.getClient();
-    this.eventQueue = client.getEventQueue();
+    this.eventQueue = client.get(ScheduledExecutorService.class);
   }
   
   @Override

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/AbstractRedditCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/AbstractRedditCommand.java
@@ -29,7 +29,7 @@ public abstract class AbstractRedditCommand extends AbstractGuildCommand {
   public AbstractRedditCommand(SlashCommandEvent event, GuildCommandManager manager) {
     super(manager);
     this.event = event;
-    this.reddit = manager.getClient().getSubredditObservable();
+    this.reddit = manager.getClient().get(SubredditObservable.class);
     this.channel = event.getTextChannel();
   }
   

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/BlacklistAddCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/BlacklistAddCommand.java
@@ -43,7 +43,7 @@ public class BlacklistAddCommand extends AbstractGuildCommand {
   public BlacklistAddCommand(SlashCommandEvent event, GuildCommandManager manager) {
     super(manager);
     this.event = event;
-    this.cache = manager.getClient().getPatternCache();
+    this.cache = manager.getClient().get(PatternCache.class);
   }
 
   @Override

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/BlacklistRemoveCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/BlacklistRemoveCommand.java
@@ -27,7 +27,7 @@ public class BlacklistRemoveCommand extends AbstractGuildCommand {
   public BlacklistRemoveCommand(SlashCommandEvent event, GuildCommandManager manager) {
     super(manager);
     this.event = event;
-    this.cache = manager.getClient().getPatternCache();
+    this.cache = manager.getClient().get(PatternCache.class);
   }
 
   @Override

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/LegacyRedditRemoveCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/LegacyRedditRemoveCommand.java
@@ -58,7 +58,7 @@ public class LegacyRedditRemoveCommand extends AbstractGuildCommand {
     this.event = event;
     this.guild = event.getGuild();
     this.client = manager.getClient();
-    this.reddit = client.getSubredditObservable();
+    this.reddit = client.get(SubredditObservable.class);
     this.channel = event.getTextChannel();
   }
   

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/ResponseAddCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/ResponseAddCommand.java
@@ -29,7 +29,7 @@ public class ResponseAddCommand extends AbstractGuildCommand {
   public ResponseAddCommand(SlashCommandEvent event, GuildCommandManager manager) {
     super(manager);
     this.event = event;
-    this.cache = manager.getClient().getAutoResponseCache();
+    this.cache = manager.getClient().get(AutoResponseCache.class);
   }
 
   @Override

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/ResponseRemoveCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/ResponseRemoveCommand.java
@@ -27,7 +27,7 @@ public class ResponseRemoveCommand extends AbstractGuildCommand {
   public ResponseRemoveCommand(SlashCommandEvent event, GuildCommandManager manager) {
     super(manager);
     this.event = event;
-    this.cache = manager.getClient().getAutoResponseCache();
+    this.cache = manager.getClient().get(AutoResponseCache.class);
   }
 
   @Override

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/job/RedditJob.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/job/RedditJob.java
@@ -44,7 +44,7 @@ public class RedditJob implements Runnable {
    */
   @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
   public RedditJob(Client client) {
-    this.observable = client.getSubredditObservable();
+    this.observable = client.get(SubredditObservable.class);
     this.postConstruct(client, new TextChannelInitializer(observable));
     this.postConstruct(client, new WebhookInitializer(observable));
   }

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/AbstractTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/AbstractTest.java
@@ -87,11 +87,11 @@ public class AbstractTest {
   @BeforeEach
   public void initMocks() {
     lenient().when(client.getShards()).thenReturn(List.of(jda));
-    lenient().when(client.getSubredditObservable()).thenReturn(subredditObservable);
-    lenient().when(client.getEventQueue()).thenReturn(queue);
-    lenient().when(client.getPatternCache()).thenReturn(patternCache);
-    lenient().when(client.getCredentials()).thenReturn(credentials);
-    lenient().when(client.getAutoResponseCache()).thenReturn(responseCache);
+    lenient().when(client.get(SubredditObservable.class)).thenReturn(subredditObservable);
+    lenient().when(client.get(ScheduledExecutorService.class)).thenReturn(queue);
+    lenient().when(client.get(PatternCache.class)).thenReturn(patternCache);
+    lenient().when(client.get(Credentials.class)).thenReturn(credentials);
+    lenient().when(client.get(AutoResponseCache.class)).thenReturn(responseCache);
     
     lenient().when(jda.getGuilds()).thenReturn(List.of(guild));
     lenient().when(jda.getPresence()).thenReturn(presence);


### PR DESCRIPTION
Instead of having a getter for each object that is hold by the application client, a general setter and getter is used. The implementation is a lightweight alternative to Spring BeanContext.