### PR TITLE
Separate the global application context from the shard context.

### DIFF
--- a/zav.discord.blanc.api/src/main/java/zav/discord/blanc/api/Client.java
+++ b/zav.discord.blanc.api/src/main/java/zav/discord/blanc/api/Client.java
@@ -17,23 +17,18 @@
 package zav.discord.blanc.api;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import net.dv8tion.jda.api.JDA;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.jetbrains.annotations.Contract;
-import zav.discord.blanc.api.util.ApplicationContext;
+import zav.discord.blanc.api.util.AbstractApplicationContext;
 import zav.discord.blanc.api.util.ShardSupplier;
 
 /**
  * The application instance over all shards.
  */
 @NonNullByDefault
-public class Client implements ApplicationContext {
-  private final List<JDA> shards = new ArrayList<>();
-  private final Map<Class<?>, Object> context = new HashMap<>();
+public class Client extends AbstractApplicationContext {
+  private final List<Shard> shards = new ArrayList<>();
   
   /**
    * Creates and initializes all shards.
@@ -51,7 +46,7 @@ public class Client implements ApplicationContext {
    * @return As described.
    */
   @Contract(pure = true)
-  public List<JDA> getShards() {
+  public List<Shard> getShards() {
     return List.copyOf(shards);
   }
   
@@ -63,27 +58,9 @@ public class Client implements ApplicationContext {
    * @return The shard in which the guild is located.
    */
   @Contract(pure = true)
-  public JDA getShard(long guildId) {
+  public Shard getShard(long guildId) {
     // @See https://discord.com/developers/docs/topics/gateway#sharding
     long index = (guildId >> 22) % shards.size();
     return shards.get((int) index);
-  }
-
-  @Override
-  @Contract(pure = true)
-  public <T> T get(Class<T> clazz) {
-    Object result = context.get(clazz);
-
-    if (result == null) {
-      throw new NoSuchElementException("No element bound for " + clazz.toString());
-    }
-
-    return clazz.cast(result);
-  }
-
-  @Override
-  @Contract(mutates = "this")
-  public <T> void bind(Class<T> clazz, T object) {
-    context.put(clazz, object);
   }
 }

--- a/zav.discord.blanc.api/src/main/java/zav/discord/blanc/api/CommandProvider.java
+++ b/zav.discord.blanc.api/src/main/java/zav/discord/blanc/api/CommandProvider.java
@@ -12,9 +12,9 @@ public interface CommandProvider {
    * {@link Optional#empty()} is returned. Each command is uniquely identified by its qualified
    * name.
    *
-   * @param client The Discord instance.
+   * @param shard The current shard.
    * @param event The event from which the command is created.
    * @return An optional containing the created command.
    */
-  Optional<Command> create(Client client, SlashCommandEvent event);
+  Optional<Command> create(Shard shard, SlashCommandEvent event);
 }

--- a/zav.discord.blanc.api/src/main/java/zav/discord/blanc/api/Shard.java
+++ b/zav.discord.blanc.api/src/main/java/zav/discord/blanc/api/Shard.java
@@ -1,0 +1,45 @@
+package zav.discord.blanc.api;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import net.dv8tion.jda.api.JDA;
+import zav.discord.blanc.api.util.AbstractApplicationContext;
+
+/**
+ * A shard is a sub-component of the application. Each shard should be treated as an independent
+ * component, which is unaware of any other shards.
+ */
+@SuppressFBWarnings("EI_EXPOSE_REP2")
+public class Shard extends AbstractApplicationContext {
+  private final Client client;
+  private final JDA jda;
+  
+  /**
+   * Creates a new shard instance.
+   *
+   * @param client The application instance.
+   * @param jda The JDA instance mapped to this shard.
+   */
+  public Shard(Client client, JDA jda) {
+    this.client = client;
+    this.jda = jda;
+  }
+  
+  /**
+   * Returns the application instance belonging to this shard.
+   *
+   * @return As described.
+   */
+  public Client getClient() {
+    return client;
+  }
+  
+  /**
+   * Returns the JDA instance mapped to this shard.
+   *
+   * @return As described.
+   */
+  @SuppressFBWarnings("EI_EXPOSE_REP")
+  public JDA getJda() {
+    return jda;
+  }
+}

--- a/zav.discord.blanc.api/src/main/java/zav/discord/blanc/api/util/AbstractApplicationContext.java
+++ b/zav.discord.blanc.api/src/main/java/zav/discord/blanc/api/util/AbstractApplicationContext.java
@@ -1,0 +1,31 @@
+package zav.discord.blanc.api.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import org.jetbrains.annotations.Contract;
+
+/**
+ * Abstract implementation of an application context. Classes can be bound to singleton instances.
+ */
+public abstract class AbstractApplicationContext implements ApplicationContext {
+  private final Map<Class<?>, Object> context = new HashMap<>();
+
+  @Override
+  @Contract(pure = true)
+  public <T> T get(Class<T> clazz) {
+    Object result = context.get(clazz);
+
+    if (result == null) {
+      throw new NoSuchElementException("No element bound for " + clazz.toString());
+    }
+
+    return clazz.cast(result);
+  }
+
+  @Override
+  @Contract(mutates = "this")
+  public <T> void bind(Class<T> clazz, T object) {
+    context.put(clazz, object);
+  }
+}

--- a/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/ClientTest.java
+++ b/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/ClientTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.NoSuchElementException;
-import net.dv8tion.jda.api.JDA;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,7 +40,7 @@ import zav.discord.blanc.databind.Credentials;
 public class ClientTest {
   @Mock ShardSupplier supplier;
   @Mock Credentials credentials;
-  List<JDA> shards;
+  List<Shard> shards;
   Client client;
   
   /**
@@ -49,7 +48,7 @@ public class ClientTest {
    */
   @BeforeEach
   public void setUp() {
-    shards = List.of(mock(JDA.class), mock(JDA.class));
+    shards = List.of(mock(Shard.class), mock(Shard.class));
     
     doAnswer(invocation -> {
       shards.iterator().forEachRemaining(invocation.getArgument(0));

--- a/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/ShardTest.java
+++ b/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/ShardTest.java
@@ -1,0 +1,35 @@
+package zav.discord.blanc.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import net.dv8tion.jda.api.JDA;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Test case over an individual shard.
+ */
+@ExtendWith(MockitoExtension.class)
+public class ShardTest {
+  @Mock Client client;
+  @Mock JDA jda;
+  Shard shard;
+  
+  @BeforeEach
+  public void setUp() {
+    shard = new Shard(client, jda);
+  }
+  
+  @Test
+  public void testGetClient() {
+    assertEquals(shard.getClient(), client);
+  }
+  
+  @Test
+  public void testGetJda() {
+    assertEquals(shard.getJda(), jda);
+  }
+}

--- a/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/util/ShardSupplierTest.java
+++ b/zav.discord.blanc.api/src/test/java/zav/discord/blanc/api/util/ShardSupplierTest.java
@@ -37,9 +37,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import zav.discord.blanc.api.Client;
 import zav.discord.blanc.databind.Credentials;
 
 /**
@@ -50,6 +52,7 @@ public class ShardSupplierTest {
   ShardSupplier supplier;
   Credentials credentials;
 
+  @Mock Client client;
   MockedStatic<JDABuilder> jdaBuilder;
   MockedConstruction<TimedSemaphore> rateLimiter;
   
@@ -73,7 +76,7 @@ public class ShardSupplierTest {
     doReturn("token").when(credentials).getToken();
     doReturn(2L).when(credentials).getShardCount();
     
-    supplier = new ShardSupplier(credentials);
+    supplier = new ShardSupplier(client, credentials);
   }
   
   @AfterEach

--- a/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/CommandManager.java
+++ b/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/CommandManager.java
@@ -19,7 +19,7 @@ package zav.discord.blanc.command;
 import java.util.List;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import zav.discord.blanc.api.Client;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.command.internal.RankValidator;
 import zav.discord.blanc.databind.Rank;
 
@@ -31,9 +31,9 @@ import zav.discord.blanc.databind.Rank;
 public class CommandManager {
   
   /**
-   * The global application instance.
+   * The shard the command was executed in.
    */
-  protected final Client client;
+  protected final Shard shard;
   /**
    * The event from which the active command was created.
    */
@@ -43,11 +43,11 @@ public class CommandManager {
   /**
    * Creates a new manager instance. A new instance is created for each command.
    *
-   * @param client The global application instance.
+   * @param shard The current shard.
    * @param event The event from which the active command was created.
    */
-  public CommandManager(Client client, SlashCommandEvent event) {
-    this.client = client;
+  public CommandManager(Shard shard, SlashCommandEvent event) {
+    this.shard = shard;
     this.event = event;
     this.validator = new RankValidator(event.getUser());
   }
@@ -63,11 +63,11 @@ public class CommandManager {
   }
   
   /**
-   * Returns the application instance.
+   * Returns the current shard.
    *
    * @return  As described.
    */
-  public Client getClient() {
-    return client;
+  public Shard getShard() {
+    return shard;
   }
 }

--- a/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/GuildCommandManager.java
+++ b/zav.discord.blanc.command/src/main/java/zav/discord/blanc/command/GuildCommandManager.java
@@ -30,7 +30,7 @@ import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.interactions.components.ButtonStyle;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import zav.discord.blanc.api.Client;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.api.Site;
 import zav.discord.blanc.api.Site.Group;
 import zav.discord.blanc.api.cache.SiteCache;
@@ -51,11 +51,11 @@ public class GuildCommandManager extends CommandManager {
   /**
    * Creates a new manager instance. A new instance is created for each command.
    *
-   * @param client The Discord client.
+   * @param shard The current shard.
    * @param event The event from which the active command was created.
    */
-  public GuildCommandManager(Client client, SlashCommandEvent event) {
-    super(client, event);
+  public GuildCommandManager(Shard shard, SlashCommandEvent event) {
+    super(shard, event);
     this.textChannel = event.getTextChannel();
     this.member = Objects.requireNonNull(event.getMember());
     this.validator = new PermissionValidator(member, textChannel);
@@ -83,7 +83,7 @@ public class GuildCommandManager extends CommandManager {
     if (pages.isEmpty()) {
       event.reply("No entries.").complete();
     } else {
-      SiteCache cache = client.get(SiteCache.class);
+      SiteCache cache = shard.get(SiteCache.class);
       
       // Build site
       Site site = Site.create(pages, label);

--- a/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/CommandManagerTest.java
+++ b/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/CommandManagerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import zav.discord.blanc.api.Client;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.command.internal.RankValidator;
 import zav.discord.blanc.databind.Rank;
 
@@ -20,7 +20,7 @@ import zav.discord.blanc.databind.Rank;
 @ExtendWith(MockitoExtension.class)
 public class CommandManagerTest {
   @Mock InsufficientRankException exception;
-  @Mock Client client;
+  @Mock Shard shard;
   @Mock SlashCommandEvent event;
   CommandManager manager;
   
@@ -30,7 +30,7 @@ public class CommandManagerTest {
   @BeforeEach
   public void setUp() {
     try (var mocked = mockConstruction(RankValidator.class)) {
-      manager = new CommandManager(client, event);
+      manager = new CommandManager(shard, event);
     }
   }
   
@@ -41,7 +41,7 @@ public class CommandManagerTest {
   }
   
   @Test
-  public void testGetClient() {
-    assertEquals(manager.getClient(), client);
+  public void testGetShard() {
+    assertEquals(manager.getShard(), shard);
   }
 }

--- a/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/GuildCommandManagerTest.java
+++ b/zav.discord.blanc.command/src/test/java/zav/discord/blanc/command/GuildCommandManagerTest.java
@@ -25,7 +25,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import zav.discord.blanc.api.Client;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.api.Site;
 import zav.discord.blanc.api.cache.SiteCache;
 import zav.discord.blanc.command.internal.PermissionValidator;
@@ -40,7 +40,7 @@ public class GuildCommandManagerTest {
   @Mock Message message;
   @Mock RestAction<Message> response;
   @Mock InsufficientPermissionException exception;
-  @Mock Client client;
+  @Mock Shard shard;
   @Mock SlashCommandEvent event;
   @Mock Member member;
   @Mock ReplyAction action;
@@ -58,7 +58,7 @@ public class GuildCommandManagerTest {
   public void setUp() {
     try (var mocked = mockConstruction(PermissionValidator.class)) {
       when(event.getMember()).thenReturn(member);
-      manager = new GuildCommandManager(client, event);
+      manager = new GuildCommandManager(shard, event);
       page = Site.Page.create(entry);
     }
   }
@@ -85,7 +85,7 @@ public class GuildCommandManagerTest {
     when(action.complete()).thenReturn(hook);
     when(hook.retrieveOriginal()).thenReturn(response);
     when(response.complete()).thenReturn(message);
-    when(client.get(SiteCache.class)).thenReturn(cache);
+    when(shard.get(SiteCache.class)).thenReturn(cache);
     
     manager.submit(List.of(page), "site");
 
@@ -101,7 +101,7 @@ public class GuildCommandManagerTest {
     when(action.complete()).thenReturn(hook);
     when(hook.retrieveOriginal()).thenReturn(response);
     when(response.complete()).thenReturn(message);
-    when(client.get(SiteCache.class)).thenReturn(cache);
+    when(shard.get(SiteCache.class)).thenReturn(cache);
     
     manager.submit(List.of(page, page), "site");
 

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/core/SupportCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/core/SupportCommand.java
@@ -17,6 +17,8 @@
 package zav.discord.blanc.runtime.command.core;
 
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import zav.discord.blanc.api.Client;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.command.AbstractCommand;
 import zav.discord.blanc.command.CommandManager;
 import zav.discord.blanc.databind.Credentials;
@@ -28,6 +30,8 @@ public class SupportCommand extends AbstractCommand {
   
   private final SlashCommandEvent event;
   private final String link;
+  private final Client client;
+  private final Shard shard;
   
   /**
    * Creates a new instance of this command.
@@ -38,7 +42,9 @@ public class SupportCommand extends AbstractCommand {
   public SupportCommand(SlashCommandEvent event, CommandManager manager) {
     super(manager);
     this.event = event;
-    this.link = manager.getClient().get(Credentials.class).getInviteSupportServer();
+    this.shard = manager.getShard();
+    this.client = shard.getClient();
+    this.link = client.get(Credentials.class).getInviteSupportServer();
   }
   
   @Override

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/dev/KillCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/dev/KillCommand.java
@@ -18,9 +18,9 @@ package zav.discord.blanc.runtime.command.dev;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.concurrent.ScheduledExecutorService;
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import zav.discord.blanc.api.Client;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.command.AbstractCommand;
 import zav.discord.blanc.command.CommandManager;
 import zav.discord.blanc.databind.Rank;
@@ -30,6 +30,7 @@ import zav.discord.blanc.databind.Rank;
  */
 public class KillCommand extends AbstractCommand {
 
+  private final Shard shard;
   private final Client client;
   private final SlashCommandEvent event;
   private final ScheduledExecutorService eventQueue;
@@ -43,8 +44,9 @@ public class KillCommand extends AbstractCommand {
   public KillCommand(SlashCommandEvent event, CommandManager manager) {
     super(manager);
     this.event = event;
-    this.client = manager.getClient();
-    this.eventQueue = client.get(ScheduledExecutorService.class);
+    this.shard = manager.getShard();
+    this.client = shard.getClient();
+    this.eventQueue = shard.get(ScheduledExecutorService.class);
   }
   
   @Override
@@ -59,8 +61,8 @@ public class KillCommand extends AbstractCommand {
 
     eventQueue.shutdown();
     
-    for (JDA shard : client.getShards()) {
-      shard.shutdown();
+    for (Shard shard : client.getShards()) {
+      shard.getJda().shutdown();
     }
     
     System.exit(0);

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/AbstractRedditCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/AbstractRedditCommand.java
@@ -8,6 +8,8 @@ import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.Webhook;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import zav.discord.blanc.api.Client;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.command.AbstractGuildCommand;
 import zav.discord.blanc.command.GuildCommandManager;
 import zav.discord.blanc.reddit.SubredditObservable;
@@ -20,6 +22,8 @@ public abstract class AbstractRedditCommand extends AbstractGuildCommand {
   protected final SubredditObservable reddit;
   protected final SlashCommandEvent event;
   protected final TextChannel channel;
+  private final Client client;
+  private final Shard shard;
   private final User self;
   
   /**
@@ -31,7 +35,9 @@ public abstract class AbstractRedditCommand extends AbstractGuildCommand {
   public AbstractRedditCommand(SlashCommandEvent event, GuildCommandManager manager) {
     super(manager);
     this.event = event;
-    this.reddit = manager.getClient().get(SubredditObservable.class);
+    this.shard = manager.getShard();
+    this.client = shard.getClient();
+    this.reddit = client.get(SubredditObservable.class);
     this.channel = event.getTextChannel();
     this.self = event.getJDA().getSelfUser();
   }

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/BlacklistAddCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/BlacklistAddCommand.java
@@ -43,7 +43,7 @@ public class BlacklistAddCommand extends AbstractGuildCommand {
   public BlacklistAddCommand(SlashCommandEvent event, GuildCommandManager manager) {
     super(manager);
     this.event = event;
-    this.cache = manager.getClient().get(PatternCache.class);
+    this.cache = manager.getShard().get(PatternCache.class);
   }
 
   @Override

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/BlacklistRemoveCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/BlacklistRemoveCommand.java
@@ -27,7 +27,7 @@ public class BlacklistRemoveCommand extends AbstractGuildCommand {
   public BlacklistRemoveCommand(SlashCommandEvent event, GuildCommandManager manager) {
     super(manager);
     this.event = event;
-    this.cache = manager.getClient().get(PatternCache.class);
+    this.cache = manager.getShard().get(PatternCache.class);
   }
 
   @Override

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/LegacyRedditRemoveCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/LegacyRedditRemoveCommand.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import zav.discord.blanc.api.Client;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.command.AbstractGuildCommand;
 import zav.discord.blanc.command.GuildCommandManager;
 import zav.discord.blanc.databind.GuildEntity;
@@ -41,6 +42,7 @@ import zav.discord.blanc.reddit.SubredditObservable;
 @Deprecated
 public class LegacyRedditRemoveCommand extends AbstractGuildCommand {
   private final Client client;
+  private final Shard shard;
   private final SubredditObservable reddit;
   private final TextChannel channel;
   private final SlashCommandEvent event;
@@ -56,7 +58,8 @@ public class LegacyRedditRemoveCommand extends AbstractGuildCommand {
     super(manager);
     this.event = event;
     this.guild = event.getGuild();
-    this.client = manager.getClient();
+    this.shard = manager.getShard();
+    this.client = shard.getClient();
     this.reddit = client.get(SubredditObservable.class);
     this.channel = event.getTextChannel();
   }

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/ResponseAddCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/ResponseAddCommand.java
@@ -29,7 +29,7 @@ public class ResponseAddCommand extends AbstractGuildCommand {
   public ResponseAddCommand(SlashCommandEvent event, GuildCommandManager manager) {
     super(manager);
     this.event = event;
-    this.cache = manager.getClient().get(AutoResponseCache.class);
+    this.cache = manager.getShard().get(AutoResponseCache.class);
   }
 
   @Override

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/ResponseRemoveCommand.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/command/mod/ResponseRemoveCommand.java
@@ -27,7 +27,7 @@ public class ResponseRemoveCommand extends AbstractGuildCommand {
   public ResponseRemoveCommand(SlashCommandEvent event, GuildCommandManager manager) {
     super(manager);
     this.event = event;
-    this.cache = manager.getClient().get(AutoResponseCache.class);
+    this.cache = manager.getShard().get(AutoResponseCache.class);
   }
 
   @Override

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/internal/SimpleCommandParser.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/internal/SimpleCommandParser.java
@@ -4,10 +4,10 @@ import java.util.Optional;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import zav.discord.blanc.api.Client;
 import zav.discord.blanc.api.Command;
 import zav.discord.blanc.api.CommandParser;
 import zav.discord.blanc.api.CommandProvider;
+import zav.discord.blanc.api.Shard;
 
 /**
  * An implementation of the command parser using Guice. Dependency injection is used to inject the
@@ -15,22 +15,22 @@ import zav.discord.blanc.api.CommandProvider;
  */
 public class SimpleCommandParser implements CommandParser {
   private static final Logger LOGGER = LoggerFactory.getLogger(SimpleCommandParser.class);
-  private final Client client;
+  private final Shard shard;
   private final CommandProvider provider;
   
   /**
    * Creates a new instance of this class.
    *
-   * @param client The global application instance.
+   * @param shard The current shard.
    */
-  public SimpleCommandParser(Client client, CommandProvider provider) {
-    this.client = client;
+  public SimpleCommandParser(Shard shard, CommandProvider provider) {
+    this.shard = shard;
     this.provider = provider;
   }
   
   @Override
   public Optional<Command> parse(SlashCommandEvent event) {
-    Optional<Command> command = provider.create(client, event);
+    Optional<Command> command = provider.create(shard, event);
     
     if (command.isEmpty()) {
       LOGGER.error("Unknown slash command {}.", event.getName());

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/internal/SimpleCommandProvider.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/internal/SimpleCommandProvider.java
@@ -5,9 +5,9 @@ import java.util.List;
 import java.util.Optional;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.jetbrains.annotations.Contract;
-import zav.discord.blanc.api.Client;
 import zav.discord.blanc.api.Command;
 import zav.discord.blanc.api.CommandProvider;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.command.CommandManager;
 import zav.discord.blanc.command.GuildCommandManager;
 import zav.discord.blanc.runtime.command.core.MathCommand;
@@ -38,23 +38,23 @@ import zav.discord.blanc.runtime.command.mod.ResponseRemoveCommand;
 public class SimpleCommandProvider implements CommandProvider {
   
   @Override
-  public Optional<Command> create(Client client, SlashCommandEvent event) {
+  public Optional<Command> create(Shard shard, SlashCommandEvent event) {
     if (event.isFromGuild()) {
-      return Optional.ofNullable(createGuildCommand(client, event));
+      return Optional.ofNullable(createGuildCommand(shard, event));
     } else {
-      return Optional.ofNullable(createCommand(client, event));
+      return Optional.ofNullable(createCommand(shard, event));
     }
   }
   
   /**
    * Creates the guild-less command corresponding to the slash event.
    *
-   * @param client The Discord instance.
+   * @param shard The current shard.
    * @param event The event from which the command is created.
    * @return The created command or {@code null}, if no matching command is found.
    */
-  private static Command createCommand(Client client, SlashCommandEvent event) {
-    CommandManager manager = new CommandManager(client, event);
+  private static Command createCommand(Shard shard, SlashCommandEvent event) {
+    CommandManager manager = new CommandManager(shard, event);
     
     switch (getQualifiedName(event)) {
       case "math":
@@ -78,12 +78,12 @@ public class SimpleCommandProvider implements CommandProvider {
    * Creates the guild command corresponding to the slash event. If no matching guild command is
    * found, a guild-less command is created.
    *
-   * @param client The Discord instance.
+   * @param shard The current shard.
    * @param event The event from which the command is created.
    * @return The created command or {@code null}, if no matching command is found.
    */
-  private static Command createGuildCommand(Client client, SlashCommandEvent event) {
-    GuildCommandManager manager = new GuildCommandManager(client, event);
+  private static Command createGuildCommand(Shard shard, SlashCommandEvent event) {
+    GuildCommandManager manager = new GuildCommandManager(shard, event);
     
     switch (getQualifiedName(event)) {
       case "mod.blacklist.add":
@@ -110,7 +110,7 @@ public class SimpleCommandProvider implements CommandProvider {
         return new ResponseInfoCommand(event, manager);
       default:
         // Guild commands are also normal commands
-        return createCommand(client, event);
+        return createCommand(shard, event);
     }
   }
   

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/job/CleanupJob.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/job/CleanupJob.java
@@ -16,11 +16,11 @@
 
 package zav.discord.blanc.runtime.job;
 
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zav.discord.blanc.api.Client;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.databind.GuildEntity;
 import zav.discord.blanc.runtime.internal.validator.TextChannelValidator;
 import zav.discord.blanc.runtime.internal.validator.WebhookValidator;
@@ -46,8 +46,8 @@ public class CleanupJob implements Runnable {
   
   @Override
   public void run() {
-    for (JDA shard : client.getShards()) {
-      for (Guild guild : shard.getGuilds()) {
+    for (Shard shard : client.getShards()) {
+      for (Guild guild : shard.getJda().getGuilds()) {
         GuildEntity entity = GuildEntity.find(guild);
 
         LOGGER.info("Remove invalid text channels from the database.");

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/job/PresenceJob.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/job/PresenceJob.java
@@ -18,11 +18,11 @@ package zav.discord.blanc.runtime.job;
 
 import java.io.IOException;
 import java.security.SecureRandom;
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Activity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zav.discord.blanc.api.Client;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.databind.Status;
 
 /**
@@ -57,8 +57,8 @@ public class PresenceJob implements Runnable {
   
   
     LOGGER.info("Change activity to '{}'.", statusMessage);
-    for (JDA shard : self.getShards()) {
-      shard.getPresence().setActivity(Activity.playing(statusMessage));
+    for (Shard shard : self.getShards()) {
+      shard.getJda().getPresence().setActivity(Activity.playing(statusMessage));
     }
   }
 }

--- a/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/job/RedditJob.java
+++ b/zav.discord.blanc.runtime/src/main/java/zav/discord/blanc/runtime/job/RedditJob.java
@@ -17,13 +17,13 @@
 package zav.discord.blanc.runtime.job;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.TextChannel;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zav.discord.blanc.api.Client;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.reddit.SubredditObservable;
 import zav.discord.blanc.reddit.TextChannelInitializer;
 import zav.discord.blanc.reddit.WebhookInitializer;
@@ -59,9 +59,9 @@ public class RedditJob implements Runnable {
    */
   public final void postConstruct(Client client, TextChannelInitializer initializer) {
     LOGGER.info("Initializing listeners for all registered text channels.");
-    for (JDA shard : client.getShards()) {
-      LOGGER.info("Initializing listeners for shard {}.", shard.getShardInfo());
-      for (Guild guild : shard.getGuilds()) {
+    for (Shard shard : client.getShards()) {
+      LOGGER.info("Initializing listeners for shard {}.", shard.getJda().getShardInfo());
+      for (Guild guild : shard.getJda().getGuilds()) {
         LOGGER.info("Initializing listeners for guild {}.", guild.getName());
         initializer.load(guild);
       }
@@ -78,9 +78,9 @@ public class RedditJob implements Runnable {
    */
   public final void postConstruct(Client client, WebhookInitializer initializer) {
     LOGGER.info("Initializing listeners for all registered webhooks.");
-    for (JDA shard : client.getShards()) {
-      LOGGER.info("Initializing listeners for shard {}.", shard.getShardInfo());
-      for (Guild guild : shard.getGuilds()) {
+    for (Shard shard : client.getShards()) {
+      LOGGER.info("Initializing listeners for shard {}.", shard.getJda().getShardInfo());
+      for (Guild guild : shard.getJda().getGuilds()) {
         LOGGER.info("Initializing listeners for guild {}.", guild.getName());
         for (TextChannel textChannel : guild.getTextChannels()) {
           if (textChannel.canTalk()) {

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/AbstractTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/AbstractTest.java
@@ -32,6 +32,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import zav.discord.blanc.api.Client;
+import zav.discord.blanc.api.Shard;
 import zav.discord.blanc.api.cache.AutoResponseCache;
 import zav.discord.blanc.api.cache.PatternCache;
 import zav.discord.blanc.command.CommandManager;
@@ -56,6 +57,7 @@ public class AbstractTest {
   public @Mock SelfUser  selfUser;
   public @Mock TextChannel channel;
   public @Mock JDA jda;
+  public @Mock Shard shard;
   public @Mock Presence presence;
   public @Mock RestAction<List<Webhook>> retrieveWebhooks;
   public @Mock WebhookAction createWebhook;
@@ -88,12 +90,14 @@ public class AbstractTest {
    */
   @BeforeEach
   public void initMocks() {
-    lenient().when(client.getShards()).thenReturn(List.of(jda));
+    lenient().when(client.getShards()).thenReturn(List.of(shard));
     lenient().when(client.get(SubredditObservable.class)).thenReturn(subredditObservable);
-    lenient().when(client.get(ScheduledExecutorService.class)).thenReturn(queue);
-    lenient().when(client.get(PatternCache.class)).thenReturn(patternCache);
     lenient().when(client.get(Credentials.class)).thenReturn(credentials);
-    lenient().when(client.get(AutoResponseCache.class)).thenReturn(responseCache);
+    lenient().when(shard.get(ScheduledExecutorService.class)).thenReturn(queue);
+    lenient().when(shard.get(PatternCache.class)).thenReturn(patternCache);
+    lenient().when(shard.get(AutoResponseCache.class)).thenReturn(responseCache);
+    lenient().when(shard.getJda()).thenReturn(jda);
+    lenient().when(shard.getClient()).thenReturn(client);
     
     lenient().when(jda.getSelfUser()).thenReturn(selfUser);
     lenient().when(jda.getGuilds()).thenReturn(List.of(guild));
@@ -108,7 +112,7 @@ public class AbstractTest {
     lenient().when(createWebhook.complete()).thenReturn(webhook);
     lenient().when(retrieveWebhooks.complete()).thenReturn(List.of(webhook));
     lenient().when(webhook.getOwner()).thenReturn(selfMember);
-    lenient().when(manager.getClient()).thenReturn(client);
+    lenient().when(manager.getShard()).thenReturn(shard);
 
     lenient().when(event.getJDA()).thenReturn(jda);
     lenient().when(event.getMember()).thenReturn(member);

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/dev/FailsafeCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/dev/FailsafeCommandTest.java
@@ -42,7 +42,7 @@ public class FailsafeCommandTest extends AbstractTest {
    */
   @BeforeEach
   public void setUp() {
-    manager = new CommandManager(client, event);
+    manager = new CommandManager(shard, event);
     command = new FailsafeCommand(event, manager);
   }
   

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/dev/KillCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/dev/KillCommandTest.java
@@ -42,7 +42,7 @@ public class KillCommandTest extends AbstractTest {
    */
   @BeforeEach
   public void setUp() {
-    manager = new CommandManager(client, event);
+    manager = new CommandManager(shard, event);
     command = new KillCommand(event, manager);
   }
   

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/BlacklistAddCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/BlacklistAddCommandTest.java
@@ -51,7 +51,7 @@ public class BlacklistAddCommandTest extends AbstractTest {
    */
   @BeforeEach
   public void setUp() {
-    manager = new GuildCommandManager(client, event);
+    manager = new GuildCommandManager(shard, event);
     command = new BlacklistAddCommand(event, manager);
   }
 

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/BlacklistInfoCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/BlacklistInfoCommandTest.java
@@ -62,7 +62,7 @@ public class BlacklistInfoCommandTest extends AbstractTest {
     when(event.getMember()).thenReturn(member);
     when(event.getGuild()).thenReturn(guild);
     
-    manager = spy(new GuildCommandManager(client, event));
+    manager = spy(new GuildCommandManager(shard, event));
     command = new BlacklistInfoCommand(event, manager);
     
     doNothing().when(manager).submit(captor.capture(), anyString());

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/BlacklistRemoveCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/BlacklistRemoveCommandTest.java
@@ -59,7 +59,7 @@ public class BlacklistRemoveCommandTest extends AbstractTest {
     when(event.getMember()).thenReturn(member);
     when(event.getGuild()).thenReturn(guild);
     
-    manager = new GuildCommandManager(client, event);
+    manager = new GuildCommandManager(shard, event);
     command = new BlacklistRemoveCommand(event, manager);
 
     guildEntity.setBlacklist(new ArrayList<>(List.of("foo")));

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/LegacyRedditInfoCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/LegacyRedditInfoCommandTest.java
@@ -56,7 +56,7 @@ public class LegacyRedditInfoCommandTest extends AbstractTest {
    */
   @BeforeEach
   public void setUp() {
-    manager = spy(new GuildCommandManager(client, event));
+    manager = spy(new GuildCommandManager(shard, event));
     command = new LegacyRedditInfoCommand(event, manager);
     channelEntity.setSubreddits(new ArrayList<>(List.of("RedditDev", "BoatsOnWheels")));
     guildEntity.setTextChannels(new ArrayList<>(List.of(channelEntity)));

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/LegacyRedditRemoveCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/LegacyRedditRemoveCommandTest.java
@@ -68,7 +68,7 @@ public class LegacyRedditRemoveCommandTest extends AbstractTest {
     channelEntity.setSubreddits(new ArrayList<>(List.of("RedditDev")));
     channelEntity.setWebhooks(Collections.emptyList());
 
-    manager = new GuildCommandManager(client, event);
+    manager = new GuildCommandManager(shard, event);
     command = new LegacyRedditRemoveCommand(event, manager);
   }
   

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/RedditAddCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/RedditAddCommandTest.java
@@ -59,7 +59,7 @@ public class RedditAddCommandTest extends AbstractTest {
   public void setUp() {
     // The webhook was created by another user, so we have to create a new instance
     when(selfMember.getIdLong()).thenReturn(Long.MAX_VALUE);
-    manager = new GuildCommandManager(client, event);
+    manager = new GuildCommandManager(shard, event);
     command = new RedditAddCommand(event, manager);
   }
   

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/RedditInfoCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/RedditInfoCommandTest.java
@@ -56,7 +56,7 @@ public class RedditInfoCommandTest extends AbstractTest {
    */
   @BeforeEach
   public void setUp() {
-    manager = spy(new GuildCommandManager(client, event));
+    manager = spy(new GuildCommandManager(shard, event));
     command = new RedditInfoCommand(event, manager);
     webhookEntity.setSubreddits(new ArrayList<>(List.of("RedditDev")));
     channelEntity.setSubreddits(new ArrayList<>(List.of("RedditDev", "BoatsOnWheels")));

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/RedditRemoveCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/RedditRemoveCommandTest.java
@@ -64,7 +64,7 @@ public class RedditRemoveCommandTest extends AbstractTest {
   public void setUp() {
     when(webhook.getName()).thenReturn(AbstractRedditCommand.WEBHOOK);
 
-    manager = new GuildCommandManager(client, event);
+    manager = new GuildCommandManager(shard, event);
     command = new RedditRemoveCommand(event, manager);
   }
   

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/ResponseAddCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/ResponseAddCommandTest.java
@@ -37,7 +37,7 @@ public class ResponseAddCommandTest extends AbstractTest {
    */
   @BeforeEach
   public void setUp() {
-    manager = new GuildCommandManager(client, event);
+    manager = new GuildCommandManager(shard, event);
     command = new ResponseAddCommand(event, manager);
 
     guildEntity.setAutoResponses(new ArrayList<>());

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/ResponseInfoCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/ResponseInfoCommandTest.java
@@ -41,7 +41,7 @@ public class ResponseInfoCommandTest extends AbstractTest {
     responseEntity.setPattern("Hello There");
     responseEntity.setAnswer("General Kenobi");
     
-    manager = spy(new GuildCommandManager(client, event));
+    manager = spy(new GuildCommandManager(shard, event));
     command = new ResponseInfoCommand(event, manager);
     
     doNothing().when(manager).submit(pages.capture(), anyString());

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/ResponseRemoveCommandTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/command/mod/ResponseRemoveCommandTest.java
@@ -38,7 +38,7 @@ public class ResponseRemoveCommandTest extends AbstractTest {
     responseEntity.setPattern("Hello There");
     responseEntity.setAnswer("General Kenobi");
     
-    manager = new GuildCommandManager(client, event);
+    manager = new GuildCommandManager(shard, event);
     command = new ResponseRemoveCommand(event, manager);
   }
 

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/internal/SimpleCommandParserTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/internal/SimpleCommandParserTest.java
@@ -27,7 +27,7 @@ public class SimpleCommandParserTest extends AbstractTest {
   
   @BeforeEach
   public void setUp() {
-    parser = new SimpleCommandParser(client, provider);
+    parser = new SimpleCommandParser(shard, provider);
   }
   
   @Test

--- a/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/internal/SimpleCommandProviderTest.java
+++ b/zav.discord.blanc.runtime/src/test/java/zav/discord/blanc/runtime/internal/SimpleCommandProviderTest.java
@@ -109,7 +109,7 @@ public class SimpleCommandProviderTest extends AbstractTest {
     
     setName(name);
     
-    assertEquals(provider.create(client, event).orElseThrow().getClass(), clazz);
+    assertEquals(provider.create(shard, event).orElseThrow().getClass(), clazz);
   }
   
   /**
@@ -141,13 +141,13 @@ public class SimpleCommandProviderTest extends AbstractTest {
     
     setName(name);
     
-    assertEquals(provider.create(client, event).orElseThrow().getClass(), clazz);
+    assertEquals(provider.create(shard, event).orElseThrow().getClass(), clazz);
   }
   
   @Test
   public void testCreateUnknownCommand() {
     setName("foo.bar");
     
-    assertTrue(provider.create(client, event).isEmpty());
+    assertTrue(provider.create(shard, event).isEmpty());
   }
 }


### PR DESCRIPTION
Each shard should use isolated instances of e.g. the command parser.

Fixes #27